### PR TITLE
Added title attributes to the main-toolbar buttons (Issue #9)

### DIFF
--- a/lib/MendixWorkshopManager.js
+++ b/lib/MendixWorkshopManager.js
@@ -88,6 +88,7 @@ define(function (require, exports, module) {
             buildDiv.addClass('mx-build');
             buildWidget.attr('src', require.toUrl('img/mendix_build_gray.png'));
             buildWidget.addClass('mx-code-snippets-main');
+            buildDiv.attr("title", "Build Custom Widget");
             buildWidget.on('click', { self: this }, MendixWorkshopManager.buildCustomWidget);
             buildDiv.append(buildWidget);
             $('#main-toolbar .buttons').prepend(buildDiv);
@@ -96,6 +97,8 @@ define(function (require, exports, module) {
             var openPanel = $('<img>');
             openPanel.attr('src', require.toUrl('img/mendix.png'));
             openPanel.addClass('mx-code-snippets-main');
+            openPanel.addClass('mx-btn-panel');
+            openPanel.attr("title", "Hide Panel");
             openPanel.on('click', { self: this }, MendixWorkshopManager.showHidePanel);
             $('#main-toolbar .buttons').prepend(openPanel);
             
@@ -179,11 +182,16 @@ define(function (require, exports, module) {
         },
 
         showHidePanel : function (event) {
+            
+            var btnPanel = document.querySelector(".mx-btn-panel");
+            
             if (MendixWorkshopManager.panel.isVisible()) {
                 MendixWorkshopManager.panel.hide();
+                btnPanel.title = "Show Panel";
                 CommandManager.get(MODULE_NAME).setChecked(false);
             } else {
                 MendixWorkshopManager.panel.show();
+                btnPanel.title = "Hide Panel";
                 CommandManager.get(MODULE_NAME).setChecked(true);
             }
         },


### PR DESCRIPTION
The title of the build custom widget button set to "Build Custom Widget"
The title of the Show/Hide panel button changes when panel open/closed. Can be either "Show Panel" or "Hide Panel".

NB: I'm a Mendix developer and this is my first github pull request. Be gentle! :)
